### PR TITLE
Add tutorials for using Survey API

### DIFF
--- a/tutorial/R/README.md
+++ b/tutorial/R/README.md
@@ -1,0 +1,63 @@
+# Accessing survey API data using R
+
+This tutorial will show how to fetch data from the survey API using R.
+
+You can take a look at the form used in the example [here](https://nettskjema.no/a/375224)
+
+## Requirements
+
+* `R`
+* `httr2`
+* `jsonlite`
+
+## Fetching a token
+
+To access data from the survey API, you will need a valid token.
+
+This assumes that you have already registered an API Key, and that the
+API Key is stored in the environment variable `$APIKEY`.
+
+```r
+library(httr2)
+library(jsonlite)
+
+api_key <- Sys.getenv("APIKEY")
+token_url <- "https://internal.api.tsd.usit.no/v1/p1337/auth/basic/token?type=survey_member"
+
+req <- request(token_url) %>%
+    req_method("POST") %>%
+    req_headers("Authorization" = paste("Bearer", api_key))
+
+resp <- req_perform(req)
+token <- resp_body_json(resp)$token
+```
+
+## Fetching metadata
+
+```r
+metadata_url <- "https://internal.api.tsd.usit.no/v1/p1337/survey/375224/metadata"
+req <- request(metadata_url) %>%
+    req_headers("Authorization" = paste("Bearer", token))
+resp <- req_perform(req)
+
+metadata <- resp_body_json(resp)[[1]]
+```
+
+## Fetching answers
+
+```r
+submissions_url <- "https://internal.api.tsd.usit.no/v1/p1337/survey/375224/submissions"
+req <- request(submissions_url) %>%
+    req_headers("Authorization" = paste("Bearer", token))
+resp <- req_perform(req)
+submissions <- resp_body_json(resp,simplifyVector=TRUE)
+
+m <- merge(submissions$answers, submissions$metadata)
+
+# Compare how many answers would like to fight the horse sized duck or the 100 
+# duck sized horses
+table(m$duck_or_horse)
+#
+#    1_duck 100_horses 
+#         8          8 
+```

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,0 +1,13 @@
+# Tutorials for accessing the Survey API from within TSD
+
+## curl
+
+See [curl](curl/README.md).
+
+## python
+
+See [python](python/README.md).
+
+## R
+
+See [R](R/README.md).

--- a/tutorial/curl/README.md
+++ b/tutorial/curl/README.md
@@ -1,0 +1,93 @@
+# Accessing survey API data using curl
+
+This tutorial will show how to fetch data from the survey API using curl.
+
+You can take a look at the form used in the example [here](https://nettskjema.no/a/375224)
+
+## Requirements
+
+* `curl`
+
+## Fetching a token
+
+To access data from the survey API, you will need a valid token.
+
+This assumes that you have already registered an API Key, and that the
+API Key is stored in the environment variable `$APIKEY`.
+
+```console
+$ curl -X POST -H "Authorization: Bearer $APIKEY" https://internal.api.tsd.usit.no/v1/p1337/auth/basic/
+token?type=survey_member
+
+{"token": "eyJhbGci....HZTtw", "refresh_token": null}
+```
+
+Save the token in the environment variable `$TOKEN`, which we will use in the rest of the tutorial.
+
+## Fetching metadata
+
+```console
+$ curl -H "Authorization: Bearer $TOKEN" https://internal.api.tsd.usit.no/v1/p1337/survey/375224/metadata
+
+[{"theme": "DEFAULT", "title": "tutorial-form", "formId": 375224, "openTo": null ...
+```
+
+To see the full response, see [metadata.json](metadata.json). More information about the format can be
+found [here](https://github.com/unioslo/survey-api-schemas/blob/master/schema/2023-03/Form.json).
+
+For most uses, the most important part of the metadata will be the data under `elements`. This contains
+information about all the questions in the survey, as well as their order.
+
+For example, here is the first element in our example form:
+
+```json
+{
+    "text": "Would you rather fight 100 duck-sized horses, or 1 horse-sized duck?",
+    "altText": null,
+    "sequence": 1,
+    "elementId": 5845750,
+    "dateFormat": null,
+    "description": null,
+    "elementType": "RADIO",
+    "subElements": [],
+    "answerOptions": [
+        {
+            "text": "100 duck-sized horses",
+            "sequence": 1,
+            "answerOptionId": 14178270,
+            "externalAnswerOptionId": "100_horses"
+        },
+        {
+            "text": "1 horse-sized duck",
+            "sequence": 2,
+            "answerOptionId": 14178271,
+            "externalAnswerOptionId": "1_duck"
+        }
+    ],
+    "isAnswerHashed": false,
+    "externalElementId": "duck_or_horse",
+    "nationalIdNumberType": null
+}
+```
+
+As we can see from the metadata, this is a question of the `RADIO` type, and it has two options. Values stored in the codebook, can be found in the properties `externalElementId` and `externalAnswerOptionId`.
+
+## Fetching submissions
+
+Fetching all submissions for our form, can be done in the following way:
+
+```console
+curl -H "Authorization: Bearer $TOKEN" https://internal.api.tsd.usit.no/v1/p1337/survey/375224/submissions
+
+[{"answers": {"fight_animal": {"cat": "win", "rat": "win", "seal": "draw", "hippo": "loss", "horse": "loss", "moose": "loss", "tiger": "loss", "beaver": "win", "elephant": "loss", "kangaroo": "loss", "crocodile": "loss", "chimpanzee": "loss"}, "duck_or_horse": "100_horses"}, "version": "2022-07", "metadata": {"created": "2023-10-30T00:00:00+01:00", "answer_time": 26515, "submission_id": 29246211}}]
+```
+
+We can also do some filtering. Lets say we only want the submissions where the `100_horses` option has been selected in the first question:
+
+```console
+curl -H "Authorization: Bearer $TOKEN" https://internal.api.tsd.usit.no/v1/p1337/survey/375224/submissions?where=answers.duck_or_horse=eq.100_horses
+
+...
+```
+
+For more info about the filtering, see [here](https://github.com/unioslo/tsd-api-docs/blob/master/integration/survey-api.md#key-filtering).

--- a/tutorial/python/README.md
+++ b/tutorial/python/README.md
@@ -1,0 +1,64 @@
+# Accessing survey API data using python
+
+This tutorial will show how to fetch data from the survey API using curl.
+
+You can take a look at the form used in the example [here](https://nettskjema.no/a/375224)
+
+## Requirements
+
+* `python >= 3.6`
+* `requests`
+
+## Fetching a token
+
+To access data from the survey API, you will need a valid token.
+
+This assumes that you have already registered an API Key, and that the
+API Key is stored in the environment variable `$APIKEY`.
+
+```python
+import os
+import requests
+
+api_key = os.getenv("APIKEY")
+headers = {"Authorization": f"Bearer {api_key}"}
+
+token_url = "https://internal.api.tsd.usit.no/v1/p1337/auth/basic/token?type=survey_member"
+resp = requests.post(token_url, headers=headers)
+
+token = resp.json()["token"]
+```
+
+## Fetching metadata
+
+```python
+headers = {"Authorization": f"Bearer {token}"}
+metadata_url = "https://internal.api.tsd.usit.no/v1/p1337/survey/375224/metadata"
+
+resp = requests.get(metadata_url, headers=headers)
+
+# The metadata response will be an array, we just pick the first one, but usually
+# you should select the metadata with the newest "generatedDate"
+# Metadata is updated if the form is reactivated or changed.
+metadata = resp.json()[0]
+
+# Get the codebook for the first question
+q_codebook = metadata["elements"][0]["externalElementId"]
+```
+
+## Fetching answers
+
+```python
+submissions_url = "https://internal.api.tsd.usit.no/v1/p1337/survey/375224/submissions"
+resp = requests.get(submissions_url, headers=headers)
+submissions = resp.json()
+
+# Print all answers to our first question
+for s in submissions:
+    print(s["answers"][q_codebook])
+
+# 100_horses
+# 1_duck
+# 1_duck
+# 100_horses
+```


### PR DESCRIPTION
I've added some very basic tutorials for how to access the survey API from within TSD.

They are fairly basic at the moment, and i want to flesh them out a bit, but for now it should at least help users to start using the API.

Currently missing documentation for how to get the API keys, as we want enable users to do this in a self-service way.

If anyone knows R, i would appreciate some feedback on the R tutorial, as it is the first thing i have ever written in R.