### PR TITLE
Ensure using latest metadata for element lookup

### DIFF
--- a/tools/2025-02_fix_undefined/find_all_undefined.sql
+++ b/tools/2025-02_fix_undefined/find_all_undefined.sql
@@ -46,9 +46,9 @@ BEGIN
                      jsonb_each(data->'answers') AS n(key, value)
                 WHERE n.value = '"undefined"';
                 $fmt$,
-                project_id, form_id, project_id, form_id 
+                project_id, form_id, project_id, form_id
             );
-            
+
             EXECUTE query;
         END LOOP;
     END LOOP;
@@ -67,9 +67,9 @@ BEGIN
     LOOP
         query := FORMAT(
             $fmt$
-            SELECT value->'elementType' as element_type from %I."%s/metadata", 
+            SELECT value->'elementType' as element_type from %I."%s/metadata",
                 LATERAL jsonb_array_elements(data->'elements') as elem
-                    WHERE elem->'externalElementId' = '"%s"';
+                    WHERE elem->'externalElementId' = '"%s"' AND data ? 'generatedDate' ORDER BY data->'generatedDate' DESC LIMIT 1;
             $fmt$,
             rec.project_id, rec.form_id, rec.key
         );


### PR DESCRIPTION
As forms often have multiple versions of metadata stored, ensure we use the latest one when doing the element type lookup if there are multiple results.