### PR TITLE
Replace number with integer for most elements

### DIFF
--- a/schema/2024-09/Form.json
+++ b/schema/2024-09/Form.json
@@ -38,7 +38,7 @@
     },
     "formId": {
       "description": "Unique identifier for the skjema.",
-      "type": "number"
+      "type": "integer"
     },
     "version": {
       "description": "An identifier which format is used. Can be used to find correct version of this schema.",
@@ -183,7 +183,7 @@
         },
         "personId": {
           "description": "Unique identifier for this person.",
-          "type": "number"
+          "type": "integer"
         },
         "username": {
           "description": "Username of the editor.",
@@ -207,7 +207,7 @@
         },
         "sequence": {
           "description": "Which question number is this.",
-          "type": "number"
+          "type": "integer"
         },
         "dateFormat": {
           "$ref": "#/$defs/dateFormat"
@@ -250,7 +250,7 @@
         },
         "numberOfDecimals": {
           "description": "How many decimals if it is a number element.",
-          "type": "number"
+          "type": "integer"
         }
       }
     },
@@ -266,7 +266,7 @@
         },
         "sequence": {
           "description": "Which question number is this.",
-          "type": "number"
+          "type": "integer"
         },
         "dateFormat": {
           "$ref": "#/$defs/dateFormat"
@@ -307,7 +307,7 @@
         },
         "sequence": {
           "description": "Which answer number is this.",
-          "type": "number"
+          "type": "integer"
         },
         "externalAnswerOptionId": {
           "description": "Codebook value for this answer option.",
@@ -315,7 +315,7 @@
         },
         "redirectToForm": {
           "description": "The form id the user will be redirected to after delivery, if this answer option was picked. If a form id is defined the element it belongs to will always have the `useForRedirectToForm` set to true. If both `redirectToForm` and `afterDeliveryForwardFormIds` is set, `useForRedirectToForm` has priority after delivery.",
-          "type": "number"
+          "type": "integer"
         }
       }
     },

--- a/schema/2024-09/Submission.bundle.json
+++ b/schema/2024-09/Submission.bundle.json
@@ -277,7 +277,7 @@
         },
         "forwarded_to_form": {
           "description": "What form was this form forwarding to?",
-          "type": "number"
+          "type": "integer"
         },
         "answer_time": {
           "description": "How many seconds did it take to answer the form.",
@@ -285,10 +285,10 @@
         },
         "submission_id": {
           "description": "Unique identifier for this submission.",
-          "type": "number"
+          "type": "integer"
         },
         "number_of_attachments": {
-          "type": "number"
+          "type": "integer"
         },
         "respondent": {
           "description": "Info about the respondent of the nettskjema.",
@@ -319,6 +319,48 @@
             "user_name": {
               "description": "User name assigned to the respondent by their IdP.",
               "type": "string"
+            },
+            "task_id": {
+              "description": "Identifier used to convey task completion in the Helsenorge-integration.",
+              "type": "string"
+            },
+            "representation": {
+              "description": "Info about the representation when a respondent is being represented by another person. Always ommited if there are no representation involved.",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "representation_type",
+                "name_authorizer",
+                "pid_authorizer",
+                "representative_name",
+                "representative_pid"
+              ],
+              "properties": {
+                "representation_type": {
+                  "description": "How the representative are represented, either by a parent or by authority.",
+                  "type": "string",
+                  "enum": [
+                    "PARENT",
+                    "AUTHORITY"
+                  ]
+                },
+                "name_authorizer": {
+                  "description": "Name of person who is being represented.",
+                  "type": "string"
+                },
+                "pid_authorizer": {
+                  "description": "National personal identifier of person who is being represented.",
+                  "type": "string"
+                },
+                "representative_name": {
+                  "description": "Name of person who represents.",
+                  "type": "string"
+                },
+                "representative_pid": {
+                  "description": "National person identifier of person who represents, this value is always equal to personal_identifier.",
+                  "type": "string"
+                }
+              }
             }
           }
         },
@@ -334,7 +376,7 @@
     },
     "version_minor": {
       "description": "Minor version of the schema. Increased for non-breaking changes.",
-      "const": 0
+      "const": 2
     }
   },
   "$defs": {
@@ -366,6 +408,86 @@
         },
         "user_name": {
           "description": "User name assigned to the respondent by their IdP.",
+          "type": "string"
+        },
+        "task_id": {
+          "description": "Identifier used to convey task completion in the Helsenorge-integration.",
+          "type": "string"
+        },
+        "representation": {
+          "description": "Info about the representation when a respondent is being represented by another person. Always ommited if there are no representation involved.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "representation_type",
+            "name_authorizer",
+            "pid_authorizer",
+            "representative_name",
+            "representative_pid"
+          ],
+          "properties": {
+            "representation_type": {
+              "description": "How the representative are represented, either by a parent or by authority.",
+              "type": "string",
+              "enum": [
+                "PARENT",
+                "AUTHORITY"
+              ]
+            },
+            "name_authorizer": {
+              "description": "Name of person who is being represented.",
+              "type": "string"
+            },
+            "pid_authorizer": {
+              "description": "National personal identifier of person who is being represented.",
+              "type": "string"
+            },
+            "representative_name": {
+              "description": "Name of person who represents.",
+              "type": "string"
+            },
+            "representative_pid": {
+              "description": "National person identifier of person who represents, this value is always equal to personal_identifier.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "representation": {
+      "description": "Info about the representation when a respondent is being represented by another person. Always ommited if there are no representation involved.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "representation_type",
+        "name_authorizer",
+        "pid_authorizer",
+        "representative_name",
+        "representative_pid"
+      ],
+      "properties": {
+        "representation_type": {
+          "description": "How the representative are represented, either by a parent or by authority.",
+          "type": "string",
+          "enum": [
+            "PARENT",
+            "AUTHORITY"
+          ]
+        },
+        "name_authorizer": {
+          "description": "Name of person who is being represented.",
+          "type": "string"
+        },
+        "pid_authorizer": {
+          "description": "National personal identifier of person who is being represented.",
+          "type": "string"
+        },
+        "representative_name": {
+          "description": "Name of person who represents.",
+          "type": "string"
+        },
+        "representative_pid": {
+          "description": "National person identifier of person who represents, this value is always equal to personal_identifier.",
           "type": "string"
         }
       }

--- a/schema/2024-09/Submission.json
+++ b/schema/2024-09/Submission.json
@@ -94,7 +94,7 @@
                 },
                 "forwarded_to_form": {
                     "description": "What form was this form forwarding to?",
-                    "type": "number"
+                    "type": "integer"
                 },
                 "answer_time": {
                     "description": "How many seconds did it take to answer the form.",
@@ -102,10 +102,10 @@
                 },
                 "submission_id": {
                     "description": "Unique identifier for this submission.",
-                    "type": "number"
+                    "type": "integer"
                 },
                 "number_of_attachments": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "respondent": {
                     "$ref": "#/$defs/respondent"


### PR DESCRIPTION
Most numeric elements in the schema currently use number instead of integer as type, I've changed this to use integer in the cases where the number is always an integer.