### PR TITLE
Change minor version in submission schema to integer

### DIFF
--- a/schema/2024-09/Submission.bundle.json
+++ b/schema/2024-09/Submission.bundle.json
@@ -376,7 +376,7 @@
     },
     "version_minor": {
       "description": "Minor version of the schema. Increased for non-breaking changes.",
-      "const": 2
+      "type": "integer"
     }
   },
   "$defs": {

--- a/schema/2024-09/Submission.json
+++ b/schema/2024-09/Submission.json
@@ -121,8 +121,8 @@
             "const": "2024-09"
         },
         "version_minor": {
-            "description": "Minor version of the schema. Increased for non-breaking changes.",
-            "const": 2
+            "description": "Minor version of the schema. Increased for non-breaking changes. Current version is 2.",
+            "type": "integer"
         }
     },
     "$defs": {


### PR DESCRIPTION
Fixes the same issue seen with the Form, minor version being a constant makes submissions with any other minor version fail to validate.