### PR TITLE
Add helsenorge to submission.respondent.provider enum

### DIFF
--- a/schema/2024-09/Submission.bundle.json
+++ b/schema/2024-09/Submission.bundle.json
@@ -305,7 +305,8 @@
               "enum": [
                 "tsd",
                 "idporten",
-                "feide"
+                "feide",
+                "helsenorge"
               ]
             },
             "sub": {
@@ -375,7 +376,7 @@
       "const": "2024-09"
     },
     "version_minor": {
-      "description": "Minor version of the schema. Increased for non-breaking changes.",
+      "description": "Minor version of the schema. Increased for non-breaking changes. Current version is 2.",
       "type": "integer"
     }
   },
@@ -395,7 +396,8 @@
           "enum": [
             "tsd",
             "idporten",
-            "feide"
+            "feide",
+            "helsenorge"
           ]
         },
         "sub": {

--- a/schema/2024-09/Submission.json
+++ b/schema/2024-09/Submission.json
@@ -141,7 +141,8 @@
                     "enum": [
                         "tsd",
                         "idporten",
-                        "feide"
+                        "feide",
+                        "helsenorge"
                     ]
                 },
                 "sub": {


### PR DESCRIPTION
`helsenorge` was missing for the provider enum in submission.respondent.